### PR TITLE
Fix CloudFormation output url

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -1211,4 +1211,4 @@ Resources:
 Outputs:
   WebsiteURL:
     Description: DVSA Website URL
-    Value: {'Fn::Join': ['', ['http://dvsa-website-', {Ref: 'AWS::AccountId'}, '.s3-website-', {Ref: 'AWS::Region'}, '.amazonaws.com']]}
+    Value: {'Fn::Join': ['', ['http://dvsa-website-', {Ref: 'AWS::AccountId'}, '.s3-website.', {Ref: 'AWS::Region'}, '.amazonaws.com']]}


### PR DESCRIPTION
The CloudFormation output originally provided a URL of form `http://dvsa-website-<accountID>.s3-website-<region>.amazonaws.com/` when it should be `http://dvsa-website-<accountID>.s3-website.<region>.amazonaws.com/` (the difference being a `.` instead of a `-` before the region) in order to work.

Addresses #26.