### PR TITLE
Fix indentation in serverless framework

### DIFF
--- a/backend/src/functions/processing/sls.yml
+++ b/backend/src/functions/processing/sls.yml
@@ -20,10 +20,10 @@ functions:
       include:
         - backend/src/functions/processing/feedback_uploads.py
     events:
-    - s3:
-        bucket: 'dvsa-feedback-bucket-${self:custom.accountId}'
-        existing: true
-        event: s3:ObjectCreated:*
+      - s3:
+          bucket: 'dvsa-feedback-bucket-${self:custom.accountId}'
+          existing: true
+          event: s3:ObjectCreated:*
 
   CreateReceipt:
     name: DVSA-CREATE-RECEIPT


### PR DESCRIPTION
With wrong indentation the serverless framework is not able to create the s3 trigger